### PR TITLE
msm8956: Set monotonic property to 0

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -28,7 +28,7 @@ bluetooth.hfp.client=1
 qcom.bluetooth.soc=smd
 
 # Camera
-media.camera.ts.monotonic=1
+media.camera.ts.monotonic=0
 persist.camera.HAL3.enabled=1
 
 # CNE/DPM


### PR DESCRIPTION
* Video recording used to work fine when device boots,
but if we try recording video after a deep sleep session,
then videos recorded are frozen. This will fix the issue.

Change-Id: Icfe490252dede871852ba305276bf262ea94fbfe