### PR TITLE
Revert "msm8956: Build libprotobuf-cpp-full"

### DIFF
--- a/msm8956.mk
+++ b/msm8956.mk
@@ -200,10 +200,6 @@ PRODUCT_PACKAGES += \
 PRODUCT_PACKAGES += \
     power.msm8952
 
-# Protobuf
-PRODUCT_PACKAGES += \
-    libprotobuf-cpp-full
-
 # Qualcomm dependencies
 PRODUCT_PACKAGES += \
     libtinyxml \


### PR DESCRIPTION
This commit partially reverts 807fc07e396d1bcdf72901b17a21d7ef8b271ed4.

Change-Id: I03640d48b3323df3c7a886a0c290e22095ba531b